### PR TITLE
Use arc-sidebar on Arc "light" theme too

### DIFF
--- a/solus_sc/sidebar.py
+++ b/solus_sc/sidebar.py
@@ -60,7 +60,7 @@ class ScSidebar(Gtk.ListBox):
         self.parent_stack = parent_stack
 
         gtkTheme = self.get_settings().get_property("gtk-theme-name").lower()
-        if gtkTheme.startswith("arc ") or gtkTheme.startswith("arc-"):
+        if gtkTheme.startswith("arc ") or gtkTheme.startswith("arc-") or gtkTheme == "arc":
             self.get_style_context().add_class("arc-sidebar")
 
         items = [


### PR DESCRIPTION
This fixes arc-sidebar not showing while using the standard Arc theme (not dark or darker). It's now more pretty 33.3% of the time!

Disclaimer: This is my first pull request, so forgive me if I did something incorrectly :\