### PR TITLE
Deprecate lapack

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -112,5 +112,9 @@
 
         <!-- Replaced by vscode //-->
         <Package>vscode-ms</Package>
+
+        <!-- Incorporated into openblas //-->
+        <Package>lapack</Package>
+        <Package>lapack-devel</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
The lapack headers are now provided by openblas so that packages will build against openblas rather than the unoptimized lapack implementation. Nothing links against it anymore :D

```
Package found in Unstable repository:
Name                : lapack, version: 3.6, release: 1
Summary             : Basic Linear Algebra Subprograms
Description         : Basic Linear Algebra Subprograms
Licenses            : BSD-3-Clause
Component           : programming
Dependencies        : gfortran glibc libgcc 
Distribution        : Solus, Dist. Release: 1
Architecture        : x86_64, Installed Size: 6.27 MB, Package Size: 1.89 MB
Reverse Dependencies: lapack-devel
```
