### PR TITLE
Deprecate old qt5 package names

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -114,5 +114,11 @@
 
         <!-- Going back to findutils tyvm //-->
         <Package>mlocate</Package>
+
+        <!-- Replaced by split qt5 packages //-->
+        <Package>qt5</Package>
+        <Package>qt5-demos</Package>
+        <Package>qt5-devel</Package>
+        <Package>qt5-docs</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
There is also qt5-translations package. But I have a new package for that, so will just make it release 23 to compensate. Shouldn't impact on any of the pkgconfig stuff. 