### PR TITLE
Expanded list of components.

### DIFF
--- a/repo_data/components.xml
+++ b/repo_data/components.xml
@@ -288,29 +288,53 @@
 			</Maintainer>
 		</Component>
 
-                <Component>
-                        <Name>office</Name>
-                        <LocalName xml:lang="en">Office Software</LocalName>
-                        <Summary xml:lang="en">Office software</Summary>
-                        <Description xml:lang="en">Office software</Description>
-                        <Group>office</Group>
-                        <Maintainer>
-                                <Name>Solus Team</Name>
-                                <Email>root@solus-project.com</Email>
-                        </Maintainer>
-                </Component>
+		<Component>
+			<Name>office</Name>
+			<LocalName xml:lang="en">Office Software</LocalName>
+			<Summary xml:lang="en">Office software</Summary>
+			<Description xml:lang="en">Office software</Description>
+			<Group>office</Group>
+			<Maintainer>
+				<Name>Solus Team</Name>
+				<Email>root@solus-project.com</Email>
+			</Maintainer>
+		</Component>
 
-                <Component>
-                        <Name>office.maths</Name>
-                        <LocalName xml:lang="en">Mathematics-Oriented Software</LocalName>
-                        <Summary xml:lang="en">Mathematics-Oriented Software</Summary>
-                        <Description xml:lang="en">Mathematics-Oriented Software</Description>
-                        <Group>office</Group>
-                        <Maintainer>
-                                <Name>Solus Team</Name>
-                                <Email>root@solus-project.com</Email>
-                        </Maintainer>
-                </Component>
+		<Component>
+			<Name>office.maths</Name>
+			<LocalName xml:lang="en">Mathematics-Oriented Software</LocalName>
+			<Summary xml:lang="en">Mathematics-Oriented Software</Summary>
+			<Description xml:lang="en">Mathematics-Oriented Software</Description>
+			<Group>office</Group>
+			<Maintainer>
+				<Name>Solus Team</Name>
+				<Email>root@solus-project.com</Email>
+			</Maintainer>
+		</Component>
+
+		<Component>
+			<Name>office.notes</Name>
+			<LocalName xml:lang="en">Note-Taking Software</LocalName>
+			<Summary xml:lang="en">Note-Taking Software</Summary>
+			<Description xml:lang="en">Note-Taking Software</Description>
+			<Group>office</Group>
+			<Maintainer>
+				<Name>Solus Team</Name>
+				<Email>root@solus-project.com</Email>
+			</Maintainer>
+		</Component>
+
+		<Component>
+			<Name>office.viewers</Name>
+			<LocalName xml:lang="en">E-book and PDF Viewing Software</LocalName>
+			<Summary xml:lang="en">E-book and PDF Viewing Software</Summary>
+			<Description xml:lang="en">E-book and PDF Viewing Software</Description>
+			<Group>office</Group>
+			<Maintainer>
+				<Name>Solus Team</Name>
+				<Email>root@solus-project.com</Email>
+			</Maintainer>
+		</Component>
 
 		<Component>
 			<Name>programming</Name>
@@ -361,6 +385,18 @@
 		</Component>
 
 		<Component>
+			<Name>programming.haskell</Name>
+			<LocalName xml:lang="en">Haskell libraries</LocalName>
+			<Summary xml:lang="en">Haskell libraries</Summary>
+			<Description xml:lang="en">Haskell libraries</Description>
+			<Group>programming</Group>
+			<Maintainer>
+				<Name>Solus Team</Name>
+				<Email>root@solus-project.com</Email>
+			</Maintainer>
+		</Component>
+
+		<Component>
 			<Name>programming.python</Name>
 			<LocalName xml:lang="en">Python modules</LocalName>
 			<Summary xml:lang="en">Python modules</Summary>
@@ -389,6 +425,18 @@
 			<LocalName xml:lang="en">Java modules and libraries</LocalName>
 			<Summary xml:lang="en">Java modules and libraries</Summary>
 			<Description xml:lang="en">Java modules and libraries</Description>
+			<Group>programming</Group>
+			<Maintainer>
+				<Name>Solus Team</Name>
+				<Email>root@solus-project.com</Email>
+			</Maintainer>
+		</Component>
+
+		<Component>
+			<Name>programming.library</Name>
+			<LocalName xml:lang="en">Programming libraries</LocalName>
+			<Summary xml:lang="en">Programming libraries</Summary>
+			<Description xml:lang="en">Programming libraries</Description>
 			<Group>programming</Group>
 			<Maintainer>
 				<Name>Solus Team</Name>


### PR DESCRIPTION
List:

- office.notes: There is a plethora of note-taking applications in the repository, ranging from gnome-todo to QOwnNotes.
- office.viewers: We have a variety of e-book and PDF viewing applications and it would be valuable to have them in a dedicated space.
- programming.haskell: Because oh god is there a lot of them in `programming`.
- programming.library: There currently is no place to put "generic" programming libraries. Just do a search via `eopkg search lib` and it starts to explain the siutation.

Note: "Why is there looking like a change for a couple components?" - They were using spaces, whereas the rest uses tabs, so I fixed that.