### PR TITLE
Add PHPStorm to third party software

### DIFF
--- a/eopkg_assist/backend.py
+++ b/eopkg_assist/backend.py
@@ -63,6 +63,8 @@ APPS = {
         "network/web/browser/opera-stable/pspec.xml",
     "google-talkplugin":
         "network/im/google-talkplugin/pspec.xml",
+    "phpstorm":
+        "programming/phpstorm/pspec.xml",
     "plexmediaserver":
         "multimedia/video/plexmediaserver/pspec.xml",
     "pycharm":

--- a/solus_sc/thirdparty.py
+++ b/solus_sc/thirdparty.py
@@ -78,6 +78,10 @@ APPS = {
         ('Opera', 'opera-browser',
          'Opera Web Browser',
          'network/web/browser/opera-stable/pspec.xml'),
+    'phpstorm':
+        ('PHPStorm', 'phpstorm',
+         'PHPStorm - an IDE for the PHP Language',
+         'programming/phpstorm/pspec.xml'),
     'plexmediaserver':
         ('Plex Media Server', 'plex',
          'Plex Media Server',


### PR DESCRIPTION
It's already in [3rd-party](https://github.com/solus-project/3rd-party), so I thought you might as well include it in the Software Center

This was asked here on Phabricator : https://dev.solus-project.com/T2107