### PR TITLE
Mark audacious-devel as obsolete

### DIFF
--- a/repo_data/distribution.xml
+++ b/repo_data/distribution.xml
@@ -137,5 +137,8 @@
 
         <!-- Replaced by nautilus-extension-devel //-->
         <Package>nautilus-devel</Package>
+
+        <!-- Replaced by audacious-libs-devel //-->
+        <Package>audacious-devel</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
Have moved the libs and devel to audacious-libs{,-devel}

Needs to be deprecated before it can be completed as it pulls in audacious-devel before audacious-libs-devel.