### PR TITLE
Update for appstream-glib 0.5+

### DIFF
--- a/app_crap.py
+++ b/app_crap.py
@@ -8,7 +8,7 @@ store = AS.Store()
 store.load(AS.StoreLoadFlags.APP_INFO_SYSTEM)
 
 def test_markup(desc):
-    m = AS.markup_convert(desc, -1, AS.MarkupConvertFormat.SIMPLE)
+    m = AS.markup_convert_simple(desc, -1)
     return m
 
 app = store.get_app_by_pkgname("pitivi")

--- a/app_crap.py
+++ b/app_crap.py
@@ -8,7 +8,7 @@ store = AS.Store()
 store.load(AS.StoreLoadFlags.APP_INFO_SYSTEM)
 
 def test_markup(desc):
-    m = AS.markup_convert_simple(desc, -1)
+    m = AS.markup_convert_simple(desc)
     return m
 
 app = store.get_app_by_pkgname("pitivi")

--- a/solus_sc/details.py
+++ b/solus_sc/details.py
@@ -279,7 +279,6 @@ class PackageDetailsView(Gtk.VBox):
 
     def render_plain(self, input_string):
         """ Render a plain version of the description, no markdown """
-        plain = As.markup_convert(input_string, -1,
-                                  As.MarkupConvertFormat.SIMPLE)
+        plain = As.markup_convert_simple(input_string, -1)
         plain = plain.replace("&quot;", "\"").replace("&apos;", "'")
         return plain

--- a/solus_sc/details.py
+++ b/solus_sc/details.py
@@ -279,6 +279,6 @@ class PackageDetailsView(Gtk.VBox):
 
     def render_plain(self, input_string):
         """ Render a plain version of the description, no markdown """
-        plain = As.markup_convert_simple(input_string, -1)
+        plain = As.markup_convert_simple(input_string)
         plain = plain.replace("&quot;", "\"").replace("&apos;", "'")
         return plain

--- a/solus_sc/package_view.py
+++ b/solus_sc/package_view.py
@@ -183,6 +183,6 @@ class ScPackageView(Gtk.VBox):
 
     def render_plain(self, input_string):
         """ Render a plain version of the description, no markdown """
-        plain = As.markup_convert_simple(input_string, -1)
+        plain = As.markup_convert_simple(input_string)
         plain = plain.replace("&quot;", "\"").replace("&apos;", "'")
         return plain

--- a/solus_sc/package_view.py
+++ b/solus_sc/package_view.py
@@ -183,7 +183,6 @@ class ScPackageView(Gtk.VBox):
 
     def render_plain(self, input_string):
         """ Render a plain version of the description, no markdown """
-        plain = As.markup_convert(input_string, -1,
-                                  As.MarkupConvertFormat.SIMPLE)
+        plain = As.markup_convert_simple(input_string, -1)
         plain = plain.replace("&quot;", "\"").replace("&apos;", "'")
         return plain

--- a/solus_sc/search_results.py
+++ b/solus_sc/search_results.py
@@ -245,7 +245,6 @@ class ScSearchResults(Gtk.VBox):
 
     def render_plain(self, input_string):
         """ Render a plain version of the description, no markdown """
-        plain = As.markup_convert(input_string, -1,
-                                  As.MarkupConvertFormat.SIMPLE)
+        plain = As.markup_convert_simple(input_string, -1)
         plain = plain.replace("&quot;", "\"").replace("&apos;", "'")
         return plain

--- a/solus_sc/search_results.py
+++ b/solus_sc/search_results.py
@@ -245,6 +245,6 @@ class ScSearchResults(Gtk.VBox):
 
     def render_plain(self, input_string):
         """ Render a plain version of the description, no markdown """
-        plain = As.markup_convert_simple(input_string, -1)
+        plain = As.markup_convert_simple(input_string)
         plain = plain.replace("&quot;", "\"").replace("&apos;", "'")
         return plain


### PR DESCRIPTION
This change set requires appstream-glib 0.5.0 or greater. The (unused) _len arguments were removed from appstream-glib in 0.5.0.

Also, simplify `markup_convert(..., As.MarkupConvertFormat.SIMPLE)` to `markup_convert_simple(...)` instead.