### PR TITLE
Fix #T2697: action_show_updates takes no extra parameters

### DIFF
--- a/solus_update/application.py
+++ b/solus_update/application.py
@@ -310,7 +310,7 @@ class ScUpdateApp(Gio.Application):
         self.notification = Notify.Notification.new(title, body, icon_name)
         self.notification.set_timeout(UPDATE_NOTIF_TIMEOUT)
         self.notification.add_action("open-sc", _("Open Software Center"),
-                                     self.action_show_updates)
+                                     self.action_show_updates, None)
         self.notification.show()
 
     def store_update_time(self):


### PR DESCRIPTION
Last parameter was missing in Notify::add_action, which would be a parameter passed to the callback - which we don't make use of. Due to that the SC didn't open on button press.

Resulted in the error:
```
~/solus/solus-sc $ ./solus-update-checker
TypeError: action_show_updates() takes exactly 4 arguments (3 given)
```