### PR TITLE
Typo: Aplications -> Applications

### DIFF
--- a/repo_data/components.xml.in
+++ b/repo_data/components.xml.in
@@ -35,7 +35,7 @@
 				<Email>root@solus-project.com</Email>
 			</Maintainer>
 		</Component>
-				
+	
 		<Component>
 			<Name>system.devel</Name>
 			<_LocalName>Base development tools</_LocalName>
@@ -98,7 +98,7 @@
 
 		<Component>
 			<Name>xorg.apps</Name>
-			<_LocalName>X.Org Core Aplications</_LocalName>
+			<_LocalName>X.Org Core Applications</_LocalName>
 			<_Summary>X.Org Core Applications</_Summary>
 			<_Description>Collection of simple applications for X.Org</_Description>
 			<Group>system</Group>


### PR DESCRIPTION
Fixed typo in <_LocalName> for xorg.apps component