### PR TITLE
repo_data: Obsolete split nx packages in favour of nx-libs

### DIFF
--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -163,5 +163,10 @@
         <Package>faac</Package>
         <Package>faac-devel</Package>
         <Package>faac-utils</Package>
+
+        <!-- Replaced by nx-libs //-->
+        <Package>nxcomp</Package>
+        <Package>nxcomp-devel</Package>
+        <Package>nxproxy</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
I was trying to use these packages in the repo, no dice. Built the combined lib and bam, no issues....they were never used by anything (including as a rundep for x2goserver).