### PR TITLE
Fix incorrect icon names for some Third Party applications.

### DIFF
--- a/solus_sc/thirdparty.py
+++ b/solus_sc/thirdparty.py
@@ -47,7 +47,7 @@ APPS = {
          'Developer channel for the web browser from Google',
          'network/web/browser/google-chrome-unstable/pspec.xml'),
     'google-earth':
-        ('Google Earth', 'earth',
+        ('Google Earth', 'google-earth',
          '3D interface for satellite imagery from Google',
          'network/web/google-earth/pspec.xml'),
     'google-talkplugin':
@@ -55,7 +55,7 @@ APPS = {
          'The Google Talk plugin for hangouts video and audio',
          'network/im/google-talkplugin/pspec.xml'),
     'gitkraken':
-        ('GitKraken', 'web-github',
+        ('GitKraken', 'gitkraken',
          'The downright luxurious Git client, for Windows, Mac and Linux',
          'programming/gitkraken/pspec.xml'),
     'idea':
@@ -92,7 +92,7 @@ APPS = {
          '</i>',
          'network/im/skype/pspec.xml'),
     'slack-desktop':
-        ('Slack', 'web-slack',
+        ('Slack', 'slack',
          'Team communication for the 21st century.',
          'network/im/slack-desktop/pspec.xml'),
     'spotify':


### PR DESCRIPTION
After some testing with Papirus Icon Theme, I discovered that some Third Party applications were not name as accurately as possible, and while some items such as GitKraken did not exist at the time of inclusion (or at least, to my knowledge) and thus added by applying similar icons like web-github, such icons have been added to Moka since then.

I've validated that the icons being changed do have corresponding icons in Moka (list below), the default icon theme, thus this update should not affect existing users. I've also opened up PapirusDevelopmentTeam/papirus-icon-theme#515 to hopefully get a Moneydance icon landed and thus complete Third Party (as it currently stands) for SC.

- `/usr/share/icons/Moka/64x64/apps/gitkraken.png`
- `/usr/share/icons/Moka/64x64/web/google-earth.png`
- `/usr/share/icons/Moka/64x64/web/slack.png`