### PR TITLE
Deprecate apache-maven-32bit-dbginfo

### DIFF
--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -202,5 +202,8 @@
         <!-- Stray //-->
         <Package>gnonlin</Package>
 
+        <!-- We don't have 32bit maven, this guy got left behind somewhere along the way //-->
+        <Package>apache-maven-32bit-dbginfo</Package>
+
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
* We don't have 32bit maven, nor can I find history of it being in the repo,
  however, it was likely deprecated at one point and this guy got left behind.

Signed-off-by: Joey Riches <josephriches@gmail.com>