### PR TITLE
Deprecate streamlink-twitch-gui-dbginfo

### DIFF
--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -202,5 +202,8 @@
         <!-- Stray //-->
         <Package>gnonlin</Package>
 
+        <!-- Debug has to be disabled for this package //-->
+        <Package>streamlink-twitch-gui-dbginfo</Package>
+
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
* Debug enabled for this package produced something unusable

Upstream commit: https://dev.solus-project.com/R3825:2eaba3a54c1f0ef34f2b79845e01b443301d7b18

Signed-off-by: Joey Riches <josephriches@gmail.com>