### PR TITLE
repo: deprecate gfortran-32bit

### DIFF
--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -209,5 +209,8 @@
         <!-- Now mesa-demos //-->
         <Package>mesalib-demos</Package>
 
+        <!-- Now libgfortran-32bit //-->
+        <Package>gfortran-32bit</Package>
+
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
Moving the gfortran libs into its own libgfortran packages results in a name
change for the 32bit package.

Signed-off-by: Peter O'Connor <peter@solus-project.com>