### PR TITLE
Peerunity is being replaced with Peercoin.

### DIFF
--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -214,5 +214,7 @@
 
         <!-- Debug has to be disabled for this package //-->
         <Package>streamlink-twitch-gui-dbginfo</Package>
+        <!-- Replaced by peercoin //-->
+        <Package>peerunity</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
Peerunity is being replaced with the official Peercoin client. This is due to the fact that Peerunity work has since been merged into Peercoin and there has been changes made to Peercoin's blockchain that require use of a 0.6 or above client.