### PR TITLE
repo: Deprecate python3-xlib, now part of python-xlib

### DIFF
--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -216,5 +216,9 @@
         <Package>streamlink-twitch-gui-dbginfo</Package>
         <!-- Replaced by peercoin //-->
         <Package>peerunity</Package>
+	
+	<!-- Merged into python-xlib // -->
+	<Package>python3-xlib</Package>
+	
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
 python3-xlib and python-xlib have the same source, so let's merge them