### PR TITLE
repo: deprecate python3-decorator

### DIFF
--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -219,6 +219,8 @@
 	
 	<!-- Merged into python-xlib // -->
 	<Package>python3-xlib</Package>
+	<!-- Merged into python-decorator // -->
+	<Package>python3-decorator</Package>
 	
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
now part of python-decorator