### PR TITLE
Deprecate captiva and pacifica icon themes.

### DIFF
--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -171,6 +171,7 @@
 
         <!-- DOA upstream //-->
         <Package>arc-firefox-theme</Package>
+        <Package>pacifica-icon-theme</Package>
 
         <!-- Replaced with autogen-libs //-->
         <Package>libautogen</Package>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -171,6 +171,7 @@
 
         <!-- DOA upstream //-->
         <Package>arc-firefox-theme</Package>
+        <Package>captiva-icon-theme</Package>
         <Package>pacifica-icon-theme</Package>
 
         <!-- Replaced with autogen-libs //-->


### PR DESCRIPTION
Proposal to deprecate pacifica-icon-theme for the reason that it's a dead upstream, with no release tarballs or activity in years. LaunchPad hasn't seen an update in 221 weeks and in fact I had originally created an issue back when I used Ubuntu **14.04 Trusty** (see https://github.com/fsvh/pacifica-icon-theme/issues/5) about support, which was never something that had occurred (and another issue about icon request was never responded to: https://github.com/fsvh/pacifica-icon-theme/issues/4).