### PR TITLE
Deprecate libcutl as it can't build against against modern libboost

### DIFF
--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -230,5 +230,9 @@
         <!-- Dropped in MATE 1.20 //-->
         <Package>mate-polkit-devel</Package>
 
+        <!-- No longer used to build xsd, libboost compatibility issues //-->
+        <Package>libcutl</Package>
+        <Package>libcutl-devel</Package>
+
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
xsd now builds with internal versions and is exactly the same size

Signed-off-by: Peter O'Connor <peter@solus-project.com>