### PR TITLE
Deprecate skrooge-devel package as it's no longer built

### DIFF
--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -234,5 +234,8 @@
         <Package>libcutl</Package>
         <Package>libcutl-devel</Package>
 
+        <!-- The -devel package is no longer built //-->
+        <Package>skrooge-devel</Package>
+
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
Signed-off-by: Peter O'Connor <peter@solus-project.com>