### PR TITLE
repo_data: deprecate flat-plat-gtk-theme

### DIFF
--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -234,5 +234,12 @@
         <Package>libcutl</Package>
         <Package>libcutl-devel</Package>
 
+        <!-- Replaced by materia-gtk-theme //-->
+        <Package>flat-plat-gtk-theme</Package>
+        <Package>flat-plat-gtk-theme-compact</Package>
+        <Package>flat-plat-gtk-theme-dark</Package>
+        <Package>flat-plat-gtk-theme-dark-compact</Package>
+        <Package>flat-plat-gtk-theme-light</Package>
+        <Package>flat-plat-gtk-theme-light-compact</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
`Flat-Plat` theme name was changed to `Materia`

Signed-off-by: Pierre-Yves <pyu@riseup.net>