### PR TITLE
Deprecate livestreamer

### DIFF
--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -240,5 +240,8 @@
         <!-- Kodi now ships this //-->
         <Package>kodi-addon-inputstream-adaptive</Package>
 
+        <!-- Dead upstream, replaced by fork streamlink //-->
+        <Package>livestreamer</Package>
+
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
* Dead upstream, replaced by well-maintained fork streamlink in repo

Signed-off-by: Joey Riches <josephriches@gmail.com>