### PR TITLE
repo_data: Deprecate qupzilla and qupzilla-devel

### DIFF
--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -240,5 +240,9 @@
         <!-- Kodi now ships this //-->
         <Package>kodi-addon-inputstream-adaptive</Package>
 
+        <!-- Replaced by falkon //-->
+        <Package>qupzilla</Package>
+        <Package>qupzilla-devel</Package>
+
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
Replaced by D2479

Signed-off-by: Peter O'Connor <peter@solus-project.com>