### PR TITLE
Deprecate yubikey-neo-manager and pycrypto

### DIFF
--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -249,5 +249,12 @@
 
         <!-- Dead upstream, replaced by fork streamlink //-->
         <Package>livestreamer</Package>
+
+        <!-- Deprecated upstream in favour of yubikey-manager-qt //-->
+        <Package>yubikey-neo-manager</Package>
+
+        <!-- Dead upstream, replaced by other py crypto libraries //-->
+        <Package>pycrypto</Package>
+
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
Deprecated upstream in favour of yubikey-manager-qt. We can also deprecate
pycrypto as yubikey-neo-manager was the only thing using it especially as pycrypto
is dead upstream and is replaced by other python crypto libraries such as pycryptodome.

Signed-off-by: Joey Riches <josephriches@gmail.com>