### PR TITLE
Deprecate many packages from Solus

### DIFF
--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -249,5 +249,37 @@
 
         <!-- Dead upstream, replaced by fork streamlink //-->
         <Package>livestreamer</Package>
+
+        <!-- Replaced by materia-gtk-theme //-->
+        <Package>flat-plat-gtk-theme</Package>
+        <Package>flat-plat-gtk-theme-compact</Package>
+        <Package>flat-plat-gtk-theme-dark</Package>
+        <Package>flat-plat-gtk-theme-dark-compact</Package>
+        <Package>flat-plat-gtk-theme-light</Package>
+        <Package>flat-plat-gtk-theme-light-compact</Package>
+
+        <!-- Deprecated upstream in favour of yubikey-manager-qt //-->
+        <Package>yubikey-neo-manager</Package>
+
+        <!-- Dead upstream, replaced by other py crypto libraries //-->
+        <Package>pycrypto</Package>
+
+        <!-- Merged into util-linux //-->
+        <Package>rfkill</Package>
+
+        <!-- Orphaned -devel packages which are no longer built //-->
+        <Package>evolution-ews-devel</Package>
+        <Package>gstreamer-vaapi-devel</Package>
+        <Package>kdeplasma-addons-devel</Package>
+        <Package>klayout-devel</Package>
+
+        <!-- Requires an ancient and insecure mozjs //-->
+        <Package>lwqq</Package>
+        <Package>lwqq-devel</Package>
+        <Package>pidgin-lwqq</Package>
+
+        <!-- Abandoned upstream with many CVEs pending //-->
+        <Package>autotrace</Package>
+        <Package>autotrace-devel</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
Combines multiple PRs into an easily mergeable (and non-conflicting) PR.
Deprecates:

- flat-plat-gtk-themes
- yubikey-neo-manager
- pycrypto
- rfkill
- Orphaned -devel packages
- lwqq and piding-lwqq
- autotrace

Signed-off-by: Peter O'Connor <peter@solus-project.com>