### PR TITLE
Deprecate nautilus-actions

### DIFF
--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -281,5 +281,12 @@
         <!-- Abandoned upstream with many CVEs pending //-->
         <Package>autotrace</Package>
         <Package>autotrace-devel</Package>
+		
+        <!-- Replaced by filemanager-actions //-->
+        <Package>nautilus-actions</Package>
+        <Package>nautilus-actions-dbginfo</Package>
+        <Package>nautilus-actions-devel</Package>
+        <Package>nautilus-actions-docs</Package>
+
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
Replaced by filemanager-actions to follow upstream

Signed-off-by: Joey Riches <josephriches@gmail.com>