### PR TITLE
Replace GNOME Tweak Tool with GNOME Tweaks.

### DIFF
--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -281,5 +281,9 @@
         <!-- Abandoned upstream with many CVEs pending //-->
         <Package>autotrace</Package>
         <Package>autotrace-devel</Package>
+
+        <!-- Replaced by gnome-tweaks //-->
+        <Package>gnome-tweak-tool</Package>
+
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
Essential for getting a usable (and accurately named) tweak tool during GNOME stack upgrade. GNOME Tweaks is 3.28.1, whereas gnome-tweak-tool is locked at 3.26 and does not function with stack upgrade.