### PR TITLE
Replace vulkan with vulkan-loader

### DIFF
--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -299,5 +299,11 @@
 
         <!-- mypaint to libmypaint //-->
         <Package>mypaint-devel</Package>
+
+       <!-- vulkan to vulkan-loader //-->
+        <Package>vulkan</Package>
+        <Package>vulkan-devel</Package>
+        <Package>vulkan-32bit</Package>
+        <Package>vulkan-32bit-devel</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
Differential in phabricator : [D3198](https://dev.solus-project.com/D3198)

Reason for change: Upstream has deprecated `Vulkan-LoaderAndValidationLayers` and split vulkan into multiple repositories. It is now `Vulkan-Loader` that provides pkgconfig(vulkan)

Signed-off-by: Pierre-Yves <pyu@riseup.net>