### PR TITLE
Drop Qt4 from qca and qscintilla packages, deprecate libykneomgr and qjson

### DIFF
--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -353,8 +353,12 @@
         <!-- Qt4 support dropped, Qt5 support folded into main packages. //-->
         <Package>qca-qt5</Package>
         <Package>qca-qt5-devel</Package>
+        <Package>qscintilla-qt5</Package>
+        <Package>qscintilla-qt5-devel</Package>
+        <Package>python-qscintilla-qt5</Package>
 
         <!-- Qt4 only library which nothing uses, part of Qt5. //-->
         <Package>qjson</Package>
+
 	</Obsoletes>
 </PISI>

--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -344,5 +344,17 @@
         <!-- Deprecated from repos. It's dead and is blocking stack upgrades. //-->
         <Package>makemkv</Package>
         <Package>makemkv-32bit-dbginfo</Package>
+
+        <!-- Only needed for yubikey-neo-manager which was already deprecated. //-->
+        <Package>libykneomgr</Package>
+        <Package>libykneomgr-dbginfo</Package>
+        <Package>libykneomgr-devel</Package>
+
+        <!-- Qt4 support dropped, Qt5 support folded into main packages. //-->
+        <Package>qca-qt5</Package>
+        <Package>qca-qt5-devel</Package>
+
+        <!-- Qt4 only library which nothing uses, part of Qt5. //-->
+        <Package>qjson</Package>
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
Qt4 deprecations as part of T6074 as well as misc libykneomgr deprecation.

Signed-off-by: Joey Riches <josephriches@gmail.com>