### PR TITLE
Update URIs to getsol.us and fix appstream-data installation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ Software Center component of the Solus Operating System. Currently undergoing
 an overhaul to drop all the stupidity and slowness that it managed to gather
 over the years.
 
-Solus Software Center is a [Solus project](https://solus-project.com/)
+Solus Software Center is a [Solus project](https://getsol.us/)
 
-![logo](https://build.solus-project.com/logo.png)
+![logo](https://build.getsol.us/logo.png)
 
 **Why not use GNOME Software?**
 
@@ -35,11 +35,9 @@ Clone the repo, and then install appstream-glib::
 
     sudo eopkg it appstream-glib
 
-Now you'll need the appdata (this is going to be packaged soon)::
+Now you'll need the appdata::
 
-    git clone https://git.solus-project.com/projects/appstream
-    cd appstream
-    ./install.sh
+    sudo eopkg it appstream-data
 
 Now just run the main launcher in this repo (don't ctrl+c, it'll explode)::
 

--- a/solus_sc/changelog.py
+++ b/solus_sc/changelog.py
@@ -24,7 +24,7 @@ CVE_URI = "https://cve.mitre.org/cgi-bin/cvename.cgi?name={}"
 
 # All TNNNN hits are Maniphest Tasks
 BUG_HIT = re.compile(r"T(\d+)")
-BUG_URI = "https://dev.solus-project.com"
+BUG_URI = "https://dev.getsol.us"
 
 # I know, it's evil. From:
 # http://daringfireball.net/2010/07/improved_regex_for_matching_urls

--- a/solus_sc/details.py
+++ b/solus_sc/details.py
@@ -442,7 +442,7 @@ class PackageDetailsView(Gtk.VBox):
         self.view_stack.add_titled(
             lic_wrap, "license", _("License"))
 
-        reportURI = "https://dev.solus-project.com/maniphest/task/edit/form/1/"
+        reportURI = "https://dev.getsol.us/maniphest/task/edit/form/1/"
         uriLab = Gtk.Label(u"\u2693 <a href=\"{}\">{}</a>".format(
             reportURI,
             _("Report an invalid or missing license")))

--- a/xng/util/markdown.py
+++ b/xng/util/markdown.py
@@ -19,7 +19,7 @@ CVE_URI = "https://cve.mitre.org/cgi-bin/cvename.cgi?name={}"
 
 # All TNNNN hits are Maniphest Tasks
 BUG_HIT = re.compile(r"T(\d+)")
-BUG_URI = "https://dev.solus-project.com"
+BUG_URI = "https://dev.getsol.us"
 
 # I know, it's evil. From:
 # http://daringfireball.net/2010/07/improved_regex_for_matching_urls


### PR DESCRIPTION
Noticed the old URIs in the Software Center changelogs and stumbled upon the other outdated things while fixing them.