### PR TITLE
Deprecate libgestures

### DIFF
--- a/repo_data/distribution.xml.in
+++ b/repo_data/distribution.xml.in
@@ -400,5 +400,10 @@
         <Package>xineramaproto</Package>
         <Package>xproto</Package>
 
+        <! -- Dead upstream, doesn't compile, isn't used. // -->
+        <Package>libgestures</Package>
+        <Package>libgestures-dbginfo</Package>
+        <Package>libgestures-devel</Package>
+
 	</Obsoletes>
 </PISI>


### PR DESCRIPTION
Part of the ChromiumOS input stack, this was packaged but never used, the other parts of the stack we are missing, which could make it un-usable AFAIK.

Additionally, doesn't rebuild against newer GCC even after applying several patches and no activity from upstream.

Signed-off-by: Joey Riches <josephriches@gmail.com>