### PR TITLE
Fix: Endless update loop after pisi_callback error

### DIFF
--- a/solus_update/application.py
+++ b/solus_update/application.py
@@ -218,7 +218,7 @@ class ScUpdateApp(Gio.Application):
         if signal == 'finished' or signal is None:
             self.invalidate_all()
             self.build_available_updates()
-        elif str(signal).startswith("tr.org.pardus.comar.Comar.PolicyKit"):
+        elif str(signal).startswith("tr.org.pardus.comar.Comar.PolicyKit") or signal == 'error':
             self.invalidate_all()
 
     def reload_repos(self):


### PR DESCRIPTION
Under some circumstances, pisi_callback can receive an error signal which isn't handled by the function.

Example debug logs: https://pastebin.com/CTExQYvn

'reload_repos()' is called once
variable 'is_updating' is set to True
'pisi_callback()' receives error signal
'invalidate_all()' won't be called
variable 'is_updating' won't reset to False
'check_update_status()' will always quit early because 'is_updating == True'

Discussion: https://discuss.getsol.us/d/827-solus-budgie-update-notification/